### PR TITLE
added new useCatalog react hook, CatalogProvider can be nested

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Dev: eslint support
+- `CatalogProvider` can be nested and they consume their parent's `catalog`
+- react-hooks support with new `useCatalog`. It is recommended to not use
+  `withCatalog` anymore but `useCatalog` whenever possible.
 
 ## 2019/03/11 0.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,6 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - react-hooks support with new `useCatalog`. It is recommended to not use
   `withCatalog` anymore but `useCatalog` whenever possible.
 
-### Removed
-
-- `Catalog` does not provide `catalog.getComponent` anymore. Instead use
-  `catalog._component` when catalog is present
-
 ## 2019/03/11 0.4.0
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - react-hooks support with new `useCatalog`. It is recommended to not use
   `withCatalog` anymore but `useCatalog` whenever possible.
 
+### Removed
+
+- `Catalog` does not provide `catalog.getComponent` anymore. Instead use
+  `catalog._component` when catalog is present
+
 ## 2019/03/11 0.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
 const App = () => {
   const { catalog } = useCatalog()
-  const Button =
-    catalog && catalog.getComponent && catalog.getComponent('Button')
+  const Button = catalog.getComponent('Button')
 
   // or you use them with the <CatalogComponent /> component
   return (

--- a/README.md
+++ b/README.md
@@ -68,6 +68,42 @@ ReactDOM.render(
 );
 ```
 
+#### Nesting CatalogProvider
+
+`<CatalogProvider />` can be nested, whereas the inner provider will extend and
+overwrite the parent provider.
+
+```js
+// setup catalogs
+const catalog = new Catalog({
+  components: {
+    OuterComponent: () => <div>OuterComponent</div>,
+    Title: ({ children }) => <h1>OuterTitle - {children}</h1>
+  },
+})
+
+const innerCatalog = new Catalog({
+  components: {
+    InnerComponent: () => <div>InnerComponent</div>,
+    Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title of the outer catalog
+  },
+})
+
+// usage
+const App = () => (
+  <CatalogProvider catalog={catalog}>
+    <CatalogProvider catalog={innerCatalog}>
+      <Content />
+    </CatalogProvider>
+  </CatalogProvider>
+)
+```
+
+`<Content />` can access components inside the `catalog` and `innerCatalog`. If
+the `innerCatalog` contains a component with the same name than in the `catalog`
+it will overwrite it. In this case `<Title />` gets overwritten in the inner
+provider.
+
 ### Import and use the catalog (with react-hooks)
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -18,15 +18,19 @@ npm i react-component-catalog --save
 
 ## Basic Usage
 
+### Requirements
+
+As this package depends on [`react-hooks`](https://reactjs.org/docs/hooks-overview.html),
+`"react": "^16.8.0"` and `"react-dom": "^16.8.0"` are required (see
+`peerDependencies` in [package.json](./package.json)).
+
 ### First register the components
 
 ```jsx
 // button.js
 import React from 'react';
 
-const Button = (props) => {
-  return <button>{props.children}</button>
-};
+const Button = (props) => <button>{props.children}</button>
 
 export default Button;
 ```
@@ -45,7 +49,7 @@ const catalog = new Catalog({
 export default catalog;
 ```
 
-### Import and use the catalog
+### Create a CatalogProvider
 
 ```jsx
 // index.js
@@ -64,39 +68,35 @@ ReactDOM.render(
 );
 ```
 
+### Import and use the catalog (with react-hooks)
+
 ```jsx
 // app.js
-import React, { Component } from 'react'
-import CatalogComponent, { withCatalog } from 'react-component-catalog'
+import React from 'react'
+// useCatalog is a react-hook
+import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
-class App extends Component {
-  constructor(props) {
-    super(props)
+const App = () => {
+  const { catalog } = useCatalog()
+  const Button =
+    catalog && catalog.getComponent && catalog.getComponent('Button')
 
-    // you can import and use registered components with catalog.getComponent
-    const { catalog } = props
-    this.Button = catalog.getComponent('Button')
-  }
-
-  render() {
-    const Button = this.Button
-
-    // or you use them with the <CatalogComponent /> component
-    return (
-      <div>
-        <CatalogComponent
-          component="Button"
-          fallbackComponent={() => <div>Button Component not found</div>}
-        >
-          Button 1
-        </CatalogComponent>
-        <Button>Button 2</Button>
-      </div>
-    )
-  }
+  // or you use them with the <CatalogComponent /> component
+  return (
+    <div>
+      <CatalogComponent component="Title">Hello Client1</CatalogComponent>
+      <CatalogComponent
+        component="Card"
+        fallbackComponent={() => <div>Component not found</div>}
+      >
+        Hello Card
+      </CatalogComponent>
+      {Button && <Button />}
+    </div>
+  )
 }
 
-export default withCatalog(App)
+export default App
 ```
 
 ## How to build and test this package

--- a/example/client/base/components/button/index.js
+++ b/example/client/base/components/button/index.js
@@ -1,7 +1,5 @@
 import React from 'react'
 
-const Button = () => {
-  return <button>Hey it's me!</button>
-}
+const Button = () => <button type="button">Hey, it is me!</button>
 
 export default Button

--- a/example/client/client1/catalog.js
+++ b/example/client/client1/catalog.js
@@ -1,24 +1,34 @@
+/* eslint-disable import/order */
+import React from 'react'
 import { Catalog } from 'react-component-catalog'
+
+import App from './components/app'
 
 // base components (or from other clients if you like)
 import Button from 'Base/components/button'
-
 /**
  * client specific components
  *
  * eg. Title: exists also in the base component, but client wants to have a
  * custom implementation
  */
-import App from './components/app'
-import Title from './components/title'
+const Title = ({ children }) => <h2>OuterTitle - {children}</h2>
 
 const catalog = new Catalog({
   components: {
     App,
     Button,
+    OuterComponent: () => <div>OuterComponent</div>,
     Title,
   },
 })
 
-export { App }
-export default catalog
+// used in a nested CatalogProvider
+const innerCatalog = new Catalog({
+  components: {
+    InnerComponent: () => <div>InnerComponent</div>, // will throw a 404 in the outer context
+    Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title
+  },
+})
+
+export { App, catalog, innerCatalog }

--- a/example/client/client1/catalog.js
+++ b/example/client/client1/catalog.js
@@ -26,7 +26,7 @@ const catalog = new Catalog({
 // used in a nested CatalogProvider
 const innerCatalog = new Catalog({
   components: {
-    InnerComponent: () => <div>InnerComponent</div>, // will throw a 404 in the outer context
+    InnerComponent: () => <div>InnerComponent</div>,
     Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title
   },
 })

--- a/example/client/client1/components/app/index.js
+++ b/example/client/client1/components/app/index.js
@@ -4,8 +4,7 @@ import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
 const App = () => {
   const { catalog } = useCatalog()
-  const Button =
-    catalog && catalog.getComponent && catalog.getComponent('Button')
+  const Button = catalog && catalog._components && catalog._components.Button
 
   // or you use them with the <CatalogComponent /> component
   return (

--- a/example/client/client1/components/app/index.js
+++ b/example/client/client1/components/app/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+
 import CatalogComponent, { withCatalog } from 'react-component-catalog'
 
 class App extends Component {

--- a/example/client/client1/components/app/index.js
+++ b/example/client/client1/components/app/index.js
@@ -4,7 +4,7 @@ import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
 const App = () => {
   const { catalog } = useCatalog()
-  const Button = catalog && catalog._components && catalog._components.Button
+  const Button = catalog.getComponent('Button')
 
   // or you use them with the <CatalogComponent /> component
   return (

--- a/example/client/client1/components/app/index.js
+++ b/example/client/client1/components/app/index.js
@@ -1,36 +1,28 @@
-import React, { Component } from 'react'
+/* eslint-disable import/order */
+import React from 'react'
+import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
-import CatalogComponent, { withCatalog } from 'react-component-catalog'
+const App = () => {
+  const { catalog } = useCatalog()
+  const Button =
+    catalog && catalog.getComponent && catalog.getComponent('Button')
 
-class App extends Component {
-  constructor(props) {
-    super(props)
-
-    // you can import and use registered components with catalog.getComponent
-    const { catalog } = props
-    this.Button =
-      catalog && catalog.getComponent && catalog.getComponent('Button')
-  }
-
-  render() {
-    const { Button } = this
-    // or you use them with the <CatalogComponent /> component
-    return (
-      <div>
-        <CatalogComponent component="Title">Hello Client1</CatalogComponent>
-        <CatalogComponent
-          component="Card"
-          fallbackComponent={() => <div>Component not found</div>}
-        >
-          Hello 404
-        </CatalogComponent>
-        {Button && <Button />}
-        <p>
-          <a href="/">Open Base</a>
-        </p>
-      </div>
-    )
-  }
+  // or you use them with the <CatalogComponent /> component
+  return (
+    <div>
+      <CatalogComponent component="Title">Hello Client1</CatalogComponent>
+      <CatalogComponent
+        component="Card"
+        fallbackComponent={() => <div>Component not found</div>}
+      >
+        Hello Card
+      </CatalogComponent>
+      {Button && <Button />}
+      <p>
+        <a href="/">Open Base</a>
+      </p>
+    </div>
+  )
 }
 
-export default withCatalog(App)
+export default App

--- a/example/client/client1/components/title/index.js
+++ b/example/client/client1/components/title/index.js
@@ -1,7 +1,0 @@
-import React from 'react'
-
-const Title = props => {
-  return <h2>{props.children}</h2>
-}
-
-export default Title

--- a/example/client/client1/index.js
+++ b/example/client/client1/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 import React from 'react'
 import ReactDOM from 'react-dom'
 

--- a/example/client/client1/index.js
+++ b/example/client/client1/index.js
@@ -1,19 +1,26 @@
 /* eslint-disable import/order */
-import React from 'react'
+import React, { Fragment } from 'react'
 import ReactDOM from 'react-dom'
 
-import catalog, { App } from './catalog'
-import { CatalogProvider } from 'react-component-catalog'
+import { App, catalog, innerCatalog } from './catalog'
+import CatalogComponent, { CatalogProvider } from 'react-component-catalog'
 
 /**
  * Showcase use of CatalogProvider, even nested ones that consume the previous
  * context (and merge their catalog with the outer catalog)
+ *
+ * NOTE: InnerComponent will throw a 404, because it is not part of catalog, but
+ * of innerCatalog
  */
 ReactDOM.render(
   <CatalogProvider catalog={catalog}>
-    <CatalogProvider>
-      <App />
-    </CatalogProvider>
+    <Fragment>
+      <CatalogComponent component="Title">Outer Title</CatalogComponent>
+      <CatalogComponent component="InnerComponent" />
+      <CatalogProvider catalog={innerCatalog}>
+        <App />
+      </CatalogProvider>
+    </Fragment>
   </CatalogProvider>,
   document.getElementById('_root'),
 )

--- a/example/client/client1/index.js
+++ b/example/client/client1/index.js
@@ -1,12 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { CatalogProvider } from 'react-component-catalog'
 
 import catalog, { App } from './catalog'
+import { CatalogProvider } from 'react-component-catalog'
 
+/**
+ * Showcase use of CatalogProvider, even nested ones that consume the previous
+ * context (and merge their catalog with the outer catalog)
+ */
 ReactDOM.render(
   <CatalogProvider catalog={catalog}>
-    <App />
+    <CatalogProvider>
+      <App />
+    </CatalogProvider>
   </CatalogProvider>,
   document.getElementById('_root'),
 )

--- a/example/package.json
+++ b/example/package.json
@@ -16,11 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/natterstefan/react-component-catalog.git"
   },
-  "keywords": [
-    "react",
-    "components",
-    "registry"
-  ],
+  "keywords": ["react", "components", "registry"],
   "author": "Stefan Natter <stefan@natter.at>",
   "license": "MIT",
   "bugs": {

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -40,6 +40,8 @@ module.exports = {
     },
   },
   resolve: {
+    // de-dupe react to be able to use hooks https://github.com/facebook/react/issues/14317#issuecomment-463097191
+    // https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react
     alias: {
       Base: resolve(__dirname, 'client/base/'),
       react: resolve(__dirname, 'node_modules/react'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6857,7 +6857,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.12.2",
@@ -7372,6 +7373,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -7897,7 +7899,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -8926,6 +8929,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9120,6 +9124,7 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
       "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9579,6 +9584,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
       "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "homepage": "https://github.com/natterstefan/react-component-catalog#readme",
   "peerDependencies": {
-    "react": "^16.8.4"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -81,6 +82,7 @@
     "jest": "^24.4.0",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4",
+    "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "rimraf": "^2.6.3",
     "size-limit": "^0.21.1",
@@ -88,7 +90,6 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^3.3.0",
-    "react": "^16.8.4"
+    "hoist-non-react-statics": "^3.3.0"
   }
 }

--- a/src/components/catalog-component.js
+++ b/src/components/catalog-component.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import React from 'react'
 
-import { withCatalog } from './with-catalog'
+import useCatalog from './use-catalog'
 
 /**
  * CatalogComponent is wrapped withCatalog by default and is capable of
@@ -24,21 +24,23 @@ import { withCatalog } from './with-catalog'
 const CatalogComponent = props => {
   const {
     // catalog props
-    catalog,
     component,
     fallbackComponent: FallbackComponent,
     // other props passed to component
     ...others
   } = props
 
-  if (!catalog || !catalog.getComponent) {
+  // get catalog from the context
+  const { catalog } = useCatalog() || {}
+
+  if (!catalog || !catalog._components) {
     console.error(
       'catalog is not defined. Please use <CatalogComponent /> in the context of a <CatalogProvider /> with an existing catalog.',
     )
     return null
   }
 
-  const Component = catalog.getComponent(component)
+  const Component = catalog._components[component]
   if (Component) {
     return <Component {...others} />
   }
@@ -50,12 +52,10 @@ const CatalogComponent = props => {
   // if no component was found, tell the developer and fail gracefully
   console.warn(
     `No component for "${component}" was found in the component catalog. The catalog contains the following components:`,
-    catalog._catalog &&
-      catalog._catalog.components &&
-      Object.keys(catalog._catalog.components),
+    catalog._components && Object.keys(catalog._components),
   )
 
   return null
 }
 
-export default withCatalog(CatalogComponent)
+export default CatalogComponent

--- a/src/components/catalog-provider.js
+++ b/src/components/catalog-provider.js
@@ -1,15 +1,19 @@
 import React from 'react'
 
 import CatalogContext from './catalog-context'
+import useCatalog from './use-catalog'
 
 /**
  * Provide the catalog to an entire react component tree via context
  */
 const CatalogProvider = props => {
   const { catalog = {}, children } = props
+  const outerCatalog = useCatalog() || {}
 
   return (
-    <CatalogContext.Provider value={{ catalog: { ...catalog } }}>
+    <CatalogContext.Provider
+      value={{ catalog: { ...outerCatalog.catalog, ...catalog } }}
+    >
       {React.Children.only(children)}
     </CatalogContext.Provider>
   )

--- a/src/components/catalog-provider.js
+++ b/src/components/catalog-provider.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import Catalog from '../lib/catalog'
+
 import CatalogContext from './catalog-context'
 import useCatalog from './use-catalog'
 
@@ -8,12 +10,26 @@ import useCatalog from './use-catalog'
  */
 const CatalogProvider = props => {
   const { catalog = {}, children } = props
-  const outerCatalog = useCatalog() || {}
+  const { catalog: outerCatalog } = useCatalog() || {}
+
+  /**
+   * if an outerCatalog (from another parent CatalogProvider) exists already, we
+   * are going to merge them together and create a new Catalog context object.
+   *
+   * Attention: the innerCatalog will overwrite the outerCatalog
+   */
+  let prepCatalog = catalog
+  if (outerCatalog) {
+    prepCatalog = new Catalog({
+      components: {
+        ...(outerCatalog && outerCatalog._components),
+        ...(catalog && catalog._components),
+      },
+    })
+  }
 
   return (
-    <CatalogContext.Provider
-      value={{ catalog: { ...outerCatalog.catalog, ...catalog } }}
-    >
+    <CatalogContext.Provider value={{ catalog: prepCatalog }}>
       {React.Children.only(children)}
     </CatalogContext.Provider>
   )

--- a/src/components/catalog-provider.test.js
+++ b/src/components/catalog-provider.test.js
@@ -16,14 +16,10 @@ describe('CatalogProvider', () => {
 
   const expectedTestCatalog = {
     catalog: {
-      _catalog: {
-        components: {
-          TestComponent,
-        },
-      },
       _components: {
         TestComponent,
       },
+      getComponent: expect.any(Function),
     },
   }
 
@@ -118,12 +114,13 @@ describe('CatalogProvider', () => {
       },
     })
 
-    const expected = new Catalog({
-      components: {
+    const expected = {
+      _components: {
         TestComponent: TestComponentTwo,
         Title,
       },
-    })
+      getComponent: expect.any(Function),
+    }
 
     const Consumer = () => {
       const catalog = useCatalog()

--- a/src/components/use-catalog.js
+++ b/src/components/use-catalog.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import CatalogContext from './catalog-context'
+
+export default function useCatalog() {
+  return React.useContext(CatalogContext)
+}

--- a/src/components/with-catalog.js
+++ b/src/components/with-catalog.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import hoistNonReactStatics from 'hoist-non-react-statics'
 
-import CatalogContext from './catalog-context'
+import useCatalog from './use-catalog'
 
 export const getDisplayName = Component => {
   return Component.displayName || Component.name || 'Component'
@@ -14,11 +14,10 @@ export const getDisplayName = Component => {
  * TODO: forwardRef (https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers)
  */
 export const withCatalog = Component => {
-  const WithCatalog = props => (
-    <CatalogContext.Consumer>
-      {context => <Component {...props} catalog={context && context.catalog} />}
-    </CatalogContext.Consumer>
-  )
+  const WithCatalog = props => {
+    const { catalog } = useCatalog() || {}
+    return <Component {...props} catalog={catalog} />
+  }
 
   WithCatalog.displayName = `WithCatalog(${getDisplayName(Component)})`
 

--- a/src/components/with-catalog.js
+++ b/src/components/with-catalog.js
@@ -15,8 +15,8 @@ export const getDisplayName = Component => {
  */
 export const withCatalog = Component => {
   const WithCatalog = props => {
-    const { catalog } = useCatalog() || {}
-    return <Component {...props} catalog={catalog} />
+    const catalog = useCatalog()
+    return <Component {...props} catalog={catalog && catalog.catalog} />
   }
 
   WithCatalog.displayName = `WithCatalog(${getDisplayName(Component)})`

--- a/src/components/with-catalog.test.js
+++ b/src/components/with-catalog.test.js
@@ -30,6 +30,18 @@ describe('withCatalog', () => {
     expect(wrapper.find(TestComponent).prop('hello')).toStrictEqual('world')
     expect(wrapper.find(TestComponent).text()).toStrictEqual('Hello World')
   })
+
+  it('renders a wrapped functional component properly, when no catalog is provided', () => {
+    const wrapper = mount(
+      <CatalogProvider>
+        <TestComponent hello="world" />
+      </CatalogProvider>,
+    )
+
+    // and the component itself
+    expect(wrapper.find(TestComponent).prop('catalog')).toBeUndefined()
+    expect(wrapper.find(TestComponent).text()).toStrictEqual('Hello World')
+  })
 })
 
 describe('getDisplayName', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import Catalog from './lib/catalog'
+// components
 import CatalogComponent from './components/catalog-component'
 import CatalogProvider from './components/catalog-provider'
 import { withCatalog } from './components/with-catalog'
+import useCatalog from './components/use-catalog'
 
-export { Catalog, CatalogComponent, CatalogProvider, withCatalog }
+export { Catalog, CatalogComponent, CatalogProvider, useCatalog, withCatalog }
 
 export default CatalogComponent

--- a/src/lib/catalog.js
+++ b/src/lib/catalog.js
@@ -1,14 +1,8 @@
 class Catalog {
-  constructor(catalog = {}) {
-    this._catalog = catalog
+  constructor(catalog) {
+    this._catalog = catalog || {}
+    this._components = (catalog && catalog.components) || {}
   }
-
-  // get a component by id, if not available we return null
-  getComponent = id =>
-    (this._catalog &&
-      this._catalog.components &&
-      this._catalog.components[id]) ||
-    null
 }
 
 export default Catalog

--- a/src/lib/catalog.js
+++ b/src/lib/catalog.js
@@ -1,8 +1,10 @@
 class Catalog {
   constructor(catalog) {
-    this._catalog = catalog || {}
     this._components = (catalog && catalog.components) || {}
   }
+
+  // get a component by id, if not available we return null
+  getComponent = id => this._components[id] || null
 }
 
 export default Catalog

--- a/src/lib/catalog.test.js
+++ b/src/lib/catalog.test.js
@@ -32,7 +32,7 @@ describe('Catalog', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(testCatalog).toEqual({
       _catalog: { components: { TestComponent } },
-      getComponent: expect.any(Function),
+      _components: { TestComponent },
     })
   })
 
@@ -43,16 +43,16 @@ describe('Catalog', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(testCatalog).toEqual({
       _catalog: {},
-      getComponent: expect.any(Function),
+      _components: {},
     })
 
     // now request a component from the catalog
-    const TestComponentFromCatalog = testCatalog.getComponent('TestComponent')
-    expect(TestComponentFromCatalog).toBeNull()
+    const TestComponentFromCatalog = testCatalog._components.TestComponent
+    expect(TestComponentFromCatalog).toBeUndefined()
   })
 
   it('returns requested component fully functional', () => {
-    const TestComponentFromCatalog = testCatalog.getComponent('TestComponent')
+    const TestComponentFromCatalog = testCatalog._components.TestComponent
     const wrapper = shallow(<TestComponentFromCatalog />)
     expect(wrapper.text()).toStrictEqual('Hello World')
   })
@@ -71,7 +71,7 @@ describe('Catalog', () => {
       },
     })
 
-    const TestButtonFromCatalog = testCatalog.getComponent('TestButton')
+    const TestButtonFromCatalog = testCatalog._components.TestButton
     const wrapper = shallow(<TestButtonFromCatalog />)
     expect(wrapper.text()).toStrictEqual('Hello Button')
 

--- a/src/lib/catalog.test.js
+++ b/src/lib/catalog.test.js
@@ -23,16 +23,16 @@ describe('Catalog', () => {
       },
     })
 
-    expect(testCatalog._catalog).toStrictEqual({
-      components: { TestComponent },
+    expect(testCatalog._components).toStrictEqual({
+      TestComponent,
     })
   })
 
   it('creates proper catalog with getComponent function', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(testCatalog).toEqual({
-      _catalog: { components: { TestComponent } },
       _components: { TestComponent },
+      getComponent: expect.any(Function),
     })
   })
 
@@ -42,17 +42,17 @@ describe('Catalog', () => {
 
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(testCatalog).toEqual({
-      _catalog: {},
       _components: {},
+      getComponent: expect.any(Function),
     })
 
     // now request a component from the catalog
-    const TestComponentFromCatalog = testCatalog._components.TestComponent
-    expect(TestComponentFromCatalog).toBeUndefined()
+    const TestComponentFromCatalog = testCatalog.getComponent('TestComponent')
+    expect(TestComponentFromCatalog).toBeNull()
   })
 
   it('returns requested component fully functional', () => {
-    const TestComponentFromCatalog = testCatalog._components.TestComponent
+    const TestComponentFromCatalog = testCatalog.getComponent('TestComponent')
     const wrapper = shallow(<TestComponentFromCatalog />)
     expect(wrapper.text()).toStrictEqual('Hello World')
   })
@@ -71,7 +71,7 @@ describe('Catalog', () => {
       },
     })
 
-    const TestButtonFromCatalog = testCatalog._components.TestButton
+    const TestButtonFromCatalog = testCatalog.getComponent('TestButton')
     const wrapper = shallow(<TestButtonFromCatalog />)
     expect(wrapper.text()).toStrictEqual('Hello Button')
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,12 +18,4 @@ module.exports = {
     libraryTarget: 'umd',
     path: resolve(__dirname, './dist'),
   },
-  // de-dupe react to be able to use hooks https://github.com/facebook/react/issues/14317#issuecomment-463097191
-  // https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react
-  resolve: {
-    alias: {
-      react: resolve('./node_modules/react'),
-      'react-dom': resolve('./node_modules/react-dom'),
-    },
-  },
 }


### PR DESCRIPTION
## TODO

- [x] `useCatalog` docs
- [x] test nesting Providers (inspired by [material-ui](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-styles/src/ThemeProvider.js) - [docs](https://material-ui.com/customization/themes/#nesting-the-theme))
- [x] add `catalog.getComponent` again

### Example

### Import and use the catalog (with react-hooks)

```js
// app.js
import React from 'react'
// useCatalog is a react-hook
import CatalogComponent, { useCatalog } from 'react-component-catalog'

const App = () => {
  const { catalog } = useCatalog()
  const Button = catalog.getComponent('Button')

  // or you use them with the <CatalogComponent /> component
  return (
    <div>
      <CatalogComponent component="Title">Hello Client1</CatalogComponent>
      <CatalogComponent
        component="Card"
        fallbackComponent={() => <div>Component not found</div>}
      >
        Hello Card
      </CatalogComponent>
      {Button && <Button />}
    </div>
  )
}

export default App
```