### PR TITLE
feat: flat catalog (no extra components prop anymore)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,18 @@ module.exports = {
   },
   rules: {
     'import/extensions': 0,
+    'import/order': [
+      'error',
+      {
+        pathGroups: [
+          {
+            pattern: 'react-component-catalog',
+            group: 'external',
+            position: 'after',
+          },
+        ],
+      },
+    ],
     'no-underscore-dangle': 0,
     'sort-keys': 0,
 
@@ -28,6 +40,10 @@ module.exports = {
 
     // typescript settings
     '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', ignoreRestSiblings: true },
+    ],
     '@typescript-eslint/interface-name-prefix': [
       2,
       {
@@ -59,7 +75,7 @@ module.exports = {
         ],
       },
       node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        extensions: ['.js', '.jsx', '.ts', '.tsx', '.d.ts'],
       },
     },
     react: {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,59 @@ npx install-peerdeps --dev react-component-catalog
 yarn add react-component-catalog -D --peer
 ```
 
+## Upgrade from 1.x.x to 2.0.0
+
+### Catalog Data Structure changes
+
+When upgrading to 2.0.0, one needs to change the `Catalog`'s data structure.
+
+```diff
+// catalog.js
+import { Catalog } from 'react-component-catalog'
+import Button from './button'
+
+-const catalog = new Catalog({
+-  components: {
+-    Button,
+-  },
+-})
++const catalog = new Catalog({
++  Button,
++})
+
+export default catalog
+```
+
+### `useCatalog` and `catalog` changes
+
+`getComponent` does not return `null` anymore when a component is not found,
+instead it returns `undefined`.
+
+```diff
+import React from 'react'
+import CatalogComponent, { useCatalog } from 'react-component-catalog'
+
+const App = () => {
+- const { catalog } = useCatalog()
++ const catalog = useCatalog()
+
+- console.log('available components', catalog._components)
++ console.log('available components', catalog._catalog)
+
+  const Button = catalog.getComponent('Button')
+
+  // ...
+}
+```
+
+### `Catalog` changes
+
+`Catalog` is not exported anymore, so code like does not work anymore:
+
+```diff
+- import { Catalog } from 'react-catalog-component'
+```
+
 ## Basic Usage
 
 ### Create a Catalog

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ export default Button
 import { Catalog } from 'react-component-catalog'
 import Button from './button'
 
-const catalog = new Catalog({
-  components: {
-    Button,
-  },
-})
+const CATALOG = {
+  Button,
+}
+
+const catalog = new Catalog(CATALOG)
 
 export default catalog
 ```
@@ -83,12 +83,10 @@ import BaseArticle from './base-article'
 import VideoArticle from './video-article'
 
 const catalog = new Catalog({
-  components: {
-    ArticlePage: {
-      AudioArticle,
-      BaseArticle,
-      VideoArticle,
-    },
+  ArticlePage: {
+    AudioArticle,
+    BaseArticle,
+    VideoArticle,
   },
 })
 
@@ -104,7 +102,7 @@ import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
 const App = props => {
   const { isAudioArticle, isVideoArticle } = props
-  const { catalog } = useCatalog()
+  const catalog = useCatalog()
 
   // get the ArticlePage object from the catalog
   const ArticlePage = catalog.getComponent('ArticlePage')
@@ -154,17 +152,13 @@ overwrite the parent provider.
 ```js
 // setup catalogs
 const catalog = new Catalog({
-  components: {
-    OuterComponent: () => <div>OuterComponent</div>,
-    Title: ({ children }) => <h1>OuterTitle - {children}</h1>,
-  },
+  OuterComponent: () => <div>OuterComponent</div>,
+  Title: ({ children }) => <h1>OuterTitle - {children}</h1>,
 })
 
 const innerCatalog = new Catalog({
-  components: {
-    InnerComponent: () => <div>InnerComponent</div>,
-    Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title of the outer catalog
-  },
+  InnerComponent: () => <div>InnerComponent</div>,
+  Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title of the outer catalog
 })
 
 // usage
@@ -191,7 +185,7 @@ import React from 'react'
 import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
 const App = () => {
-  const { catalog } = useCatalog()
+  const catalog = useCatalog()
   const Button = catalog.getComponent('Button')
 
   // you can also first check if it exists
@@ -243,7 +237,7 @@ class App extends React.Component {
   render() {
     // or <CatalogComponent component="TestComponent" ref={this.setRef} />
     return (
-      <CatalogProvider catalog={new Catalog({ components: { TestComponent } })}>
+      <CatalogProvider catalog={new Catalog({ TestComponent })}>
         <TestComponent ref={this.setRef} />
       </CatalogProvider>
     )

--- a/example/client/base/components/button/index.tsx
+++ b/example/client/base/components/button/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 
-const Button = () => <button type="button">Hey, it is me!</button>
+const Button = () => (
+  <button type="button" onClick={() => console.log('Hey :)')}>
+    Hey, it is me!
+  </button>
+)
 
 export default Button

--- a/example/client/client1/catalog.tsx
+++ b/example/client/client1/catalog.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/order */
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 
 import App from './components/app'
 
@@ -11,19 +11,30 @@ import Button from '../base/components/button'
  * eg. Title: exists also in the base component, but client wants to have a
  * custom implementation
  */
-const Title = ({ children }) => <h2>OuterTitle - {children}</h2>
+const OuterTitle: FunctionComponent = ({ children }) => (
+  <h2>OuterTitle - {children}</h2>
+)
+
+const OuterComponent: FunctionComponent = () => <div>OuterComponent</div>
+
+const InnerComponent: FunctionComponent = () => <div>InnerComponent</div>
+
+// inner CatalogProvider overwrites Title
+const InnerTitle: FunctionComponent = ({ children }) => (
+  <h2>InnerTitle - {children}</h2>
+)
 
 const catalog = {
   App,
   Button,
-  OuterComponent: () => <div>OuterComponent</div>,
-  Title,
+  OuterComponent,
+  Title: OuterTitle,
 }
 
 // used in a nested CatalogProvider
 const innerCatalog = {
-  InnerComponent: () => <div>InnerComponent</div>,
-  Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title
+  InnerComponent,
+  Title: InnerTitle,
 }
 
 export { App, catalog, innerCatalog }

--- a/example/client/client1/catalog.tsx
+++ b/example/client/client1/catalog.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/order */
 import React from 'react'
-import { Catalog } from 'react-component-catalog'
 
 import App from './components/app'
 
@@ -14,21 +13,17 @@ import Button from '../base/components/button'
  */
 const Title = ({ children }) => <h2>OuterTitle - {children}</h2>
 
-const catalog = new Catalog({
-  components: {
-    App,
-    Button,
-    OuterComponent: () => <div>OuterComponent</div>,
-    Title,
-  },
-})
+const catalog = {
+  App,
+  Button,
+  OuterComponent: () => <div>OuterComponent</div>,
+  Title,
+}
 
 // used in a nested CatalogProvider
-const innerCatalog = new Catalog({
-  components: {
-    InnerComponent: () => <div>InnerComponent</div>,
-    Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title
-  },
-})
+const innerCatalog = {
+  InnerComponent: () => <div>InnerComponent</div>,
+  Title: ({ children }) => <h2>InnerTitle - {children}</h2>, // inner CatalogProvider overwrites Title
+}
 
 export { App, catalog, innerCatalog }

--- a/example/client/client1/components/app/index.tsx
+++ b/example/client/client1/components/app/index.tsx
@@ -1,5 +1,8 @@
 import React, { FunctionComponent } from 'react'
 import CatalogComponent, { useCatalog } from 'react-component-catalog'
+const FallbackComponent: FunctionComponent = () => (
+  <div>Component not found</div>
+)
 
 const App: FunctionComponent = () => {
   const catalog = useCatalog()
@@ -9,10 +12,7 @@ const App: FunctionComponent = () => {
   return (
     <div>
       <CatalogComponent component="Title">Hello Client1</CatalogComponent>
-      <CatalogComponent
-        component="Card"
-        fallbackComponent={() => <div>Component not found</div>}
-      >
+      <CatalogComponent component="Card" fallbackComponent={FallbackComponent}>
         Hello Card
       </CatalogComponent>
       {Button && <Button />}

--- a/example/client/client1/components/app/index.tsx
+++ b/example/client/client1/components/app/index.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable import/order */
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import CatalogComponent, { useCatalog } from 'react-component-catalog'
 
-const App = () => {
-  const { catalog } = useCatalog()
+const App: FunctionComponent = () => {
+  const catalog = useCatalog()
   const Button = catalog.getComponent('Button')
 
   // or you use them with the <CatalogComponent /> component

--- a/example/server/index.js
+++ b/example/server/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-console */
 require('@babel/register')({
   babelrc: true,

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -11,5 +11,5 @@
     /* temporary workaround (https://stackoverflow.com/a/52404148/1238150) */
     "skipLibCheck": true
   },
-  "include": ["client/**/*", "server/**/*"]
+  "include": ["client/**/*", "server/**/*", "types/**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "lib/index.js",
   "module": "esm/index.js",
-  "types": "lib/index.d.ts",
+  "types": "esm/index.d.ts",
   "files": [
     "dist",
     "es",
@@ -25,11 +25,11 @@
   "scripts": {
     "build": " npm run build-types && npm run build-cjs && npm run build-es && npm run build-esm && npm run build-umd",
     "build-types": "npm run build-cjs-types && npm run build-es-types && npm run build-esm-types",
-    "build-cjs": "BABEL_ENV=cjs babel src --ignore **/@types/*,**/*.test.tsx,**/*.test.ts --out-dir lib --extensions '.ts,.tsx'",
+    "build-cjs": "BABEL_ENV=cjs babel src --ignore **/*.test.tsx,**/*.test.ts --out-dir lib --extensions '.ts,.tsx'",
     "build-cjs-types": "tsc --outDir lib --module commonjs --target es5 -d --emitDeclarationOnly",
-    "build-es": "BABEL_ENV=es babel src --ignore **/@types/*,**/*.test.tsx,**/*.test.ts --out-dir es --extensions '.ts,.tsx'",
+    "build-es": "BABEL_ENV=es babel src --ignore **/*.test.tsx,**/*.test.ts --out-dir es --extensions '.ts,.tsx'",
     "build-es-types": "tsc  --outDir es --module es2015 --target es2015 -d --emitDeclarationOnly",
-    "build-esm": "BABEL_ENV=esm babel src --ignore **/@types/*,**/*.test.tsx,**/*.test.ts --out-dir esm --extensions '.ts,.tsx'",
+    "build-esm": "BABEL_ENV=esm babel src --ignore **/*.test.tsx,**/*.test.ts --out-dir esm --extensions '.ts,.tsx'",
     "build-esm-types": "tsc --outDir esm --module es2015 --target es5 -d --emitDeclarationOnly",
     "build-umd": "BABEL_ENV=umd webpack --mode=production",
     "coverage": "jest --coverage",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,3 +1,0 @@
-// ./types/index.d.ts
-declare const __DEV__: boolean
-// https://github.com/jaredpalmer/tsdx#advanced-babel-plugin-dev-expressions

--- a/src/__tests__/catalog.test.tsx
+++ b/src/__tests__/catalog.test.tsx
@@ -10,29 +10,25 @@ const BaseArticle = () => <div>BaseArticle</div>
 const VideoArticle = () => <div>VideoArticle</div>
 
 describe('Catalog', () => {
-  let testCatalog: ICatalog
+  let testCatalog: ICatalog<any>
 
   beforeEach(() => {
     testCatalog = new Catalog({
-      components: {
-        ArticlePage: {
-          AudioArticle,
-          BaseArticle,
-          VideoArticle,
-        },
-        TestComponent,
+      ArticlePage: {
+        AudioArticle,
+        BaseArticle,
+        VideoArticle,
       },
+      TestComponent,
     })
   })
 
   it('can be created', () => {
     testCatalog = new Catalog({
-      components: {
-        TestComponent,
-      },
+      TestComponent,
     })
 
-    expect(testCatalog._components).toStrictEqual({
+    expect(testCatalog._catalog).toStrictEqual({
       TestComponent,
     })
   })
@@ -40,7 +36,7 @@ describe('Catalog', () => {
   it('creates proper catalog with getComponent function', () => {
     // eslint-disable-next-line jest/prefer-strict-equal
     expect(testCatalog).toEqual({
-      _components: {
+      _catalog: {
         ArticlePage: {
           AudioArticle,
           BaseArticle,
@@ -54,20 +50,20 @@ describe('Catalog', () => {
   })
 
   describe('getComponent', () => {
-    it('returns null for a requested component, when it was created with an empty component catalog', () => {
+    it('returns undefined for a requested component, when it was created with an empty component catalog', () => {
       // first we create an empty registry
-      testCatalog = new Catalog({ components: {} })
+      testCatalog = new Catalog({})
 
       // eslint-disable-next-line jest/prefer-strict-equal
       expect(testCatalog).toEqual({
-        _components: {},
+        _catalog: {},
         getComponent: expect.any(Function),
         hasComponent: expect.any(Function),
       })
 
       // now request a component from the catalog
       const TestComponentFromCatalog = testCatalog.getComponent('TestComponent')
-      expect(TestComponentFromCatalog).toBeNull()
+      expect(TestComponentFromCatalog).toBeUndefined()
     })
 
     it('returns requested component fully functional', () => {
@@ -85,9 +81,7 @@ describe('Catalog', () => {
       )
 
       testCatalog = new Catalog({
-        components: {
-          TestButton,
-        },
+        TestButton,
       })
 
       const TestButtonFromCatalog = testCatalog.getComponent('TestButton')
@@ -106,11 +100,11 @@ describe('Catalog', () => {
       expect(wrapper.text()).toStrictEqual('AudioArticle')
     })
 
-    it('returns null when nested requested component is not available', () => {
+    it('returns undefined when nested requested component is not available', () => {
       const TestComponentFromCatalog = testCatalog.getComponent(
         'ArticlePage.OtherArticle',
       )
-      expect(TestComponentFromCatalog).toBeNull()
+      expect(TestComponentFromCatalog).toBeUndefined()
     })
   })
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,10 +1,8 @@
-import CatalogPart from '../catalog'
 import CatalogComponentPart from '../components/catalog-component'
 import CatalogProviderPart from '../components/catalog-provider'
 import withCatalogPart from '../components/with-catalog'
 
 import ReactComponentCatalog, {
-  Catalog,
   CatalogComponent,
   CatalogProvider,
   withCatalog,
@@ -16,7 +14,6 @@ describe('react-component-catalog', () => {
   })
 
   it('exports other parts as well', () => {
-    expect(Catalog).toStrictEqual(CatalogPart)
     expect(CatalogComponent).toStrictEqual(CatalogComponentPart)
     expect(CatalogProvider).toStrictEqual(CatalogProviderPart)
     expect(withCatalog).toStrictEqual(withCatalogPart)

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,38 +1,28 @@
 import { get } from './utils'
+import { CatalogComponents } from './types'
 
-type PropertyTypes = string | number
-
-type ICatalogProperty = { [K in PropertyTypes]: any }
-
-export interface ICatalog {
+export interface ICatalog<T extends CatalogComponents = CatalogComponents> {
   // contains the raw catalog
-  _components: ICatalogProperty
+  _catalog: T | Record<string, any>
   // get a component by id, if not available it will return null
-  getComponent: (component: PropertyTypes) => any | null
+  getComponent: (component: string) => any
   // validates if the given component exists in the catalog
-  hasComponent: (component: PropertyTypes) => boolean
+  hasComponent: (component: string) => boolean
 }
 
-export interface ICatalogType {
-  components: ICatalogProperty
-}
+export class Catalog<T extends CatalogComponents = CatalogComponents>
+  implements ICatalog<T> {
+  public _catalog: T
 
-export interface ICatalogContext {
-  catalog: ICatalog
-}
-
-export class Catalog implements ICatalog {
-  public _components: ICatalog['_components']
-
-  constructor(catalog: ICatalogType) {
-    this._components = (catalog && catalog.components) || {}
+  constructor(catalog: T) {
+    this._catalog = catalog
   }
 
-  public getComponent: ICatalog['getComponent'] = component =>
-    get(this._components, component) || null
+  public getComponent: ICatalog<T>['getComponent'] = component =>
+    get(this._catalog, component)
 
-  public hasComponent: ICatalog['hasComponent'] = component =>
-    !!get(this._components, component)
+  public hasComponent: ICatalog<T>['hasComponent'] = component =>
+    !!get(this._catalog, component)
 }
 
 export default Catalog

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -7,7 +7,7 @@ export interface ICatalog<T extends CatalogComponents = CatalogComponents> {
   // get a component by id, if not available it will return null
   getComponent: (component: string) => any
   // validates if the given component exists in the catalog
-  hasComponent: (component: string) => boolean
+  hasComponent: (component: keyof T) => boolean
 }
 
 export class Catalog<T extends CatalogComponents = CatalogComponents>

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -7,7 +7,7 @@ export interface ICatalog<T extends CatalogComponents = CatalogComponents> {
   // get a component by id, if not available it will return null
   getComponent: (component: string) => any
   // validates if the given component exists in the catalog
-  hasComponent: (component: keyof T) => boolean
+  hasComponent: (component: string) => boolean
 }
 
 export class Catalog<T extends CatalogComponents = CatalogComponents>

--- a/src/components/__tests__/catalog-component.server.test.tsx
+++ b/src/components/__tests__/catalog-component.server.test.tsx
@@ -13,7 +13,7 @@ const BaseArticle = () => <div>Hello BaseArticle</div>
 
 describe('CatalogComponent', () => {
   let backupError: () => void
-  let testCatalog: ICatalog
+  let testCatalog: ICatalog<any>
 
   const components = {
     TestComponent,
@@ -29,9 +29,7 @@ describe('CatalogComponent', () => {
   }
 
   beforeEach(() => {
-    testCatalog = new Catalog({
-      components,
-    })
+    testCatalog = new Catalog(components)
 
     backupError = console.error
     console.error = jest.fn()

--- a/src/components/__tests__/catalog-component.test.tsx
+++ b/src/components/__tests__/catalog-component.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import Catalog, { ICatalog } from '../../catalog'
+import Catalog from '../../catalog'
 import CatalogComponent from '../catalog-component'
 import CatalogProvider from '../catalog-provider'
 import { withCatalog } from '../with-catalog'
@@ -15,8 +15,8 @@ const FallbackFromCatalog = () => <div>FallbackFromCatalog</div>
 
 describe('CatalogComponent', () => {
   let backupError: () => void
-  let testCatalog: ICatalog
-  let emptyTestCatalog: ICatalog
+  let testCatalog: {}
+  let emptyTestCatalog: {}
 
   const components = {
     FallbackFromCatalog,
@@ -33,13 +33,8 @@ describe('CatalogComponent', () => {
   }
 
   beforeEach(() => {
-    testCatalog = new Catalog({
-      components,
-    })
-
-    emptyTestCatalog = new Catalog({
-      components: {},
-    })
+    testCatalog = components
+    emptyTestCatalog = {}
 
     backupError = console.error
     console.error = jest.fn()
@@ -101,7 +96,7 @@ describe('CatalogComponent', () => {
 
       render() {
         return (
-          <CatalogProvider catalog={new Catalog({ components: { TestRef } })}>
+          <CatalogProvider catalog={new Catalog({ TestRef })}>
             <TestRef ref={this.setRef} />
           </CatalogProvider>
         )
@@ -131,7 +126,7 @@ describe('CatalogComponent', () => {
 
       render() {
         return (
-          <CatalogProvider catalog={new Catalog({ components: { TestRef } })}>
+          <CatalogProvider catalog={{ TestRef }}>
             <CatalogComponent component="TestRef" ref={this.setRef} />
           </CatalogProvider>
         )

--- a/src/components/__tests__/catalog-provider.test.tsx
+++ b/src/components/__tests__/catalog-provider.test.tsx
@@ -7,9 +7,11 @@ import useCatalog from '../use-catalog'
 
 const TestComponent = () => <div>Hello World</div>
 
+const DEFAULT_CATALOG = { TestComponent }
+
 describe('CatalogProvider', () => {
   let backupConsole: () => void
-  let testCatalog: {}
+  let testCatalog = DEFAULT_CATALOG
   const verifyCatalog = jest.fn()
 
   const expectedTestCatalog = {
@@ -27,7 +29,7 @@ describe('CatalogProvider', () => {
   }
 
   beforeEach(() => {
-    testCatalog = { TestComponent }
+    testCatalog = DEFAULT_CATALOG
 
     backupConsole = console.error
     console.error = jest.fn()

--- a/src/components/__tests__/catalog-provider.test.tsx
+++ b/src/components/__tests__/catalog-provider.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import Catalog, { ICatalog } from '../../catalog'
 import CatalogProvider from '../catalog-provider'
 import CatalogComponent from '../catalog-component'
 import useCatalog from '../use-catalog'
@@ -10,33 +9,25 @@ const TestComponent = () => <div>Hello World</div>
 
 describe('CatalogProvider', () => {
   let backupConsole: () => void
-  let testCatalog: ICatalog
+  let testCatalog: {}
   const verifyCatalog = jest.fn()
 
   const expectedTestCatalog = {
-    catalog: {
-      _components: {
-        TestComponent,
-      },
-      getComponent: expect.any(Function),
-      hasComponent: expect.any(Function),
+    _catalog: {
+      TestComponent,
     },
+    getComponent: expect.any(Function),
+    hasComponent: expect.any(Function),
   }
 
   const expectedEmptyCatalog = {
-    catalog: {
-      _components: {},
-      getComponent: expect.any(Function),
-      hasComponent: expect.any(Function),
-    },
+    _catalog: {},
+    getComponent: expect.any(Function),
+    hasComponent: expect.any(Function),
   }
 
   beforeEach(() => {
-    testCatalog = new Catalog({
-      components: {
-        TestComponent,
-      },
-    })
+    testCatalog = { TestComponent }
 
     backupConsole = console.error
     console.error = jest.fn()
@@ -118,15 +109,13 @@ describe('CatalogProvider', () => {
     const TestComponentTwo = () => <div>Different</div>
     const Title = () => <h2>Hello</h2>
 
-    const innerCatalog = new Catalog({
-      components: {
-        TestComponent: TestComponentTwo,
-        Title,
-      },
-    })
+    const innerCatalog = {
+      TestComponent: TestComponentTwo,
+      Title,
+    }
 
     const expected = {
-      _components: {
+      _catalog: {
         TestComponent: TestComponentTwo,
         Title,
       },
@@ -149,7 +138,7 @@ describe('CatalogProvider', () => {
       </CatalogProvider>,
     )
 
-    expect(verifyCatalog).toHaveBeenCalledWith({ catalog: expected })
+    expect(verifyCatalog).toHaveBeenCalledWith(expected)
   })
 
   it('can prefix all cataloged components with the catalogPrefix', () => {
@@ -161,7 +150,7 @@ describe('CatalogProvider', () => {
     }
 
     const expected = {
-      _components: {
+      _catalog: {
         _TestComponent: TestComponent,
       },
       getComponent: expect.any(Function),
@@ -174,27 +163,25 @@ describe('CatalogProvider', () => {
       </CatalogProvider>,
     )
 
-    expect(verifyCatalog).toHaveBeenCalledWith({ catalog: expected })
+    expect(verifyCatalog).toHaveBeenCalledWith(expected)
   })
 
   it('can be nested within another CatalogProvider, and protected by prefixing cataloged components', () => {
     const TestComponentTwo = () => <div>Different</div>
     const Title = () => <h2>Hello</h2>
 
-    const innerCatalog = new Catalog({
-      components: {
-        TestComponent: TestComponentTwo,
-        Title,
-      },
-    })
+    const innerCatalog = {
+      TestComponent: TestComponentTwo,
+      Title,
+    }
 
     const expected = {
-      _components: {
+      _catalog: {
         // innter catalog with prefix
-        _TestComponent: TestComponentTwo,
-        _Title: Title,
+        TestComponent: TestComponentTwo,
+        Title,
         // outer catalog
-        TestComponent,
+        _TestComponent: TestComponent,
       },
       getComponent: expect.any(Function),
       hasComponent: expect.any(Function),
@@ -208,13 +195,13 @@ describe('CatalogProvider', () => {
     }
 
     mount(
-      <CatalogProvider catalog={testCatalog}>
-        <CatalogProvider catalog={innerCatalog} catalogPrefix="_">
+      <CatalogProvider catalog={testCatalog} catalogPrefix="_">
+        <CatalogProvider catalog={innerCatalog}>
           <Consumer />
         </CatalogProvider>
       </CatalogProvider>,
     )
 
-    expect(verifyCatalog).toHaveBeenCalledWith({ catalog: expected })
+    expect(verifyCatalog).toHaveBeenCalledWith(expected)
   })
 })

--- a/src/components/__tests__/catalog-provider.test.tsx
+++ b/src/components/__tests__/catalog-provider.test.tsx
@@ -177,11 +177,11 @@ describe('CatalogProvider', () => {
 
     const expected = {
       _catalog: {
-        // innter catalog with prefix
+        // outer catalog has a prefix
+        _TestComponent: TestComponent,
+        // inner catalog has no prefix
         TestComponent: TestComponentTwo,
         Title,
-        // outer catalog
-        _TestComponent: TestComponent,
       },
       getComponent: expect.any(Function),
       hasComponent: expect.any(Function),

--- a/src/components/catalog-component.tsx
+++ b/src/components/catalog-component.tsx
@@ -42,8 +42,8 @@ const CatalogComponent = React.forwardRef((props: IProps, ref) => {
   } = props
 
   // get catalog from the context
-  const { catalog } = useCatalog() || {}
-  if (!catalog || !catalog._components) {
+  const catalog = useCatalog()
+  if (!catalog || typeof catalog.getComponent !== 'function') {
     if (__DEV__) {
       console.error(
         'catalog is not defined. Please, use <CatalogComponent /> in the context of a <CatalogProvider /> with an existing catalog.',
@@ -78,7 +78,7 @@ const CatalogComponent = React.forwardRef((props: IProps, ref) => {
     const errorMsg = `CatalogComponent: "${component}" not found in component catalog.`
 
     if (isClient) {
-      console.error(errorMsg, 'The catalog contains only:', catalog._components)
+      console.error(errorMsg, 'The catalog contains only:', catalog._catalog)
     } else {
       console.error(errorMsg)
     }

--- a/src/components/catalog-context.tsx
+++ b/src/components/catalog-context.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { ICatalogContext } from '../catalog'
+import { ICatalog } from '../catalog'
+import { CatalogComponents } from '../types'
 
-const CatalogContext = React.createContext<ICatalogContext>(null)
+const CatalogContext = React.createContext<ICatalog<CatalogComponents>>(null)
 
 export default CatalogContext

--- a/src/components/use-catalog.tsx
+++ b/src/components/use-catalog.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
-import { ICatalogContext } from '../catalog'
+import { ICatalog } from '../catalog'
+import { CatalogComponents } from '../types'
 
 import CatalogContext from './catalog-context'
 
 /**
- * `useCatalog` (react-hook) returns a `catalog` provided to `CatalogProvider`
+ * `useCatalog` (react-hook) returns the `catalog` provided to `CatalogProvider`
  */
-const useCatalog = (): ICatalogContext => {
-  return React.useContext(CatalogContext)
-}
+const useCatalog = <
+  T extends CatalogComponents = CatalogComponents
+>(): ICatalog<T> => React.useContext<ICatalog<T>>(CatalogContext)
 
 export default useCatalog

--- a/src/components/with-catalog.tsx
+++ b/src/components/with-catalog.tsx
@@ -18,14 +18,12 @@ export const withCatalog = (Component: ComponentType<any>) => {
   const WithCatalog = React.forwardRef((props: any, ref) => {
     const catalog = useCatalog()
 
-    return (
-      <Component {...props} catalog={catalog && catalog.catalog} ref={ref} />
-    )
+    return <Component {...props} catalog={catalog} ref={ref} />
   })
 
   WithCatalog.displayName = `WithCatalog(${getDisplayName(Component)})`
 
-  hoistNonReactStatics(WithCatalog, Component)
+  hoistNonReactStatics(WithCatalog, Component, undefined)
 
   return WithCatalog
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
-import Catalog from './catalog'
-// components
 import CatalogComponent from './components/catalog-component'
 import CatalogProvider from './components/catalog-provider'
 import { withCatalog } from './components/with-catalog'
 import useCatalog from './components/use-catalog'
 
-export { Catalog, CatalogComponent, CatalogProvider, useCatalog, withCatalog }
+export { CatalogComponent, CatalogProvider, useCatalog, withCatalog }
 
 export default CatalogComponent

--- a/src/types/custom.ts
+++ b/src/types/custom.ts
@@ -1,0 +1,3 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+// https://github.com/jaredpalmer/tsdx#advanced-babel-plugin-dev-expressions
+declare const __DEV__: boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/**
+ * This interface can be augmented by users to add types to
+ * `react-component-catalog`'s default catalog
+ */
+export interface CatalogComponents {}


### PR DESCRIPTION
## What changed

Attention: incomplete list right now.

```diff
// catalog.js
import { Catalog } from 'react-component-catalog'
import Button from './button'

-const catalog = new Catalog({
-  components: {
-    Button,
-  },
-})
+const CATALOG = {
+  Button,
+}

+const catalog = new Catalog(CATALOG)

export default catalog
```

## Tasks

- [ ] Verify if [this](https://github.com/natterstefan/react-component-catalog/pull/49/files#diff-6c58ae6ccad72d41e6c1b57e29ac7621) works as planned

```diff
+/**
+* This interface can be augmented by users to add types to
+* `react-component-catalog`'s default catalog
+*/
+export interface CatalogComponents {}
```